### PR TITLE
Improve cpu_usage handing / roll requirement to Netmiko 0.5.0

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -1044,19 +1044,19 @@ class IOSDriver(NetworkDriver):
 
         output = self.device.send_command(cpu_cmd)
         output = output.strip()
+        environment.setdefault('cpu', {})
+        environment['cpu'][0] = {}
+        environment['cpu'][0]['%usage'] = 0.0
         for line in output.splitlines():
             if 'CPU utilization' in line:
                 # CPU utilization for five seconds: 2%/0%; one minute: 2%; five minutes: 1%
                 cpu_regex = r'^.*one minute: (\d+)%; five.*$'
                 match = re.search(cpu_regex, line)
+                environment['cpu'][0]['%usage'] = float(match.group(1))
                 break
-        environment.setdefault('cpu', {})
-        environment['cpu'][0] = {}
-        environment['cpu'][0]['%usage'] = float(match.group(1))
 
         output = self.device.send_command(mem_cmd)
         output = output.strip()
-
         for line in output.splitlines():
             if 'Processor' in line:
                 _, _, _, proc_used_mem, proc_free_mem = line.split()[:5]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 napalm-base
-netmiko>=0.4.3
+netmiko>=0.5.0


### PR DESCRIPTION
See this issue here https://github.com/napalm-automation/napalm-ios/issues/15

Also add PA support, push Netmiko requirement to 0.5.0
