### PR TITLE
Add allow_agent to accepted optional args

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -65,9 +65,12 @@ class IOSDriver(NetworkDriver):
             'ssh_config_file': None,
         }
 
-        maj_ver, min_ver, bug_fix = netmiko_version.split('.')
-        # allow_agent argument is only supported starting netmiko 1.1.0
-        if int(maj_ver + min_ver + bug_fix) >= 110:
+        fields = netmiko_version.split('.')
+        fields = [int(x) for x in fields]
+        maj_ver, min_ver, bug_fix = fields
+        if maj_ver >= 2:
+            netmiko_argument_map['allow_agent'] = False
+        elif maj_ver == 1 and min_ver >= 1:
             netmiko_argument_map['allow_agent'] = False
 
         # Build dict of any optional Netmiko args

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -62,6 +62,7 @@ class IOSDriver(NetworkDriver):
             'alt_host_keys': False,
             'alt_key_file': '',
             'ssh_config_file': None,
+            'allow_agent': False,
         }
 
         # Build dict of any optional Netmiko args

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import re
 
 from netmiko import ConnectHandler, FileTransfer
+from netmiko import __version__ as netmiko_version
 from napalm_base.base import NetworkDriver
 from napalm_base.exceptions import ReplaceConfigException, MergeConfigException
 
@@ -62,8 +63,12 @@ class IOSDriver(NetworkDriver):
             'alt_host_keys': False,
             'alt_key_file': '',
             'ssh_config_file': None,
-            'allow_agent': False,
         }
+
+        maj_ver, min_ver, bug_fix = netmiko_version.split('.')
+        # allow_agent argument is only supported starting netmiko 1.1.0
+        if int(maj_ver + min_ver + bug_fix) >= 110:
+            netmiko_argument_map['allow_agent'] = False
 
         # Build dict of any optional Netmiko args
         self.netmiko_optional_args = {}


### PR DESCRIPTION
Now that netmiko supports paramiko's "allow_agent" (see https://github.com/ktbyers/netmiko/releases/tag/v1.1.0 )

This patch is to add that option to the accepted optional args for napalm-ios
