### PR TITLE
Fixing issue with lldp neighbors detail and padding

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -468,6 +468,14 @@ class IOSDriver(NetworkDriver):
         lldp = {}
         lldp_neighbors = self.get_lldp_neighbors()
 
+        # Filter to specific interface
+        if interface:
+            lldp_data = lldp_neighbors.get(interface)
+            if lldp_data:
+                lldp_neighbors = {interface: lldp_data}
+            else:
+                lldp_neighbors = {}
+
         for interface in lldp_neighbors:
             command = "show lldp neighbors {} detail".format(interface)
             output = self._send_command(command)

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -465,16 +465,6 @@ class IOSDriver(NetworkDriver):
 
         Calls get_lldp_neighbors.
         """
-        def pad_list_entries(my_list, list_length):
-            """Normalize the length of all the LLDP fields."""
-            if len(my_list) < list_length:
-                for i in range(list_length):
-                    try:
-                        my_list[i]
-                    except IndexError:
-                        my_list[i] = u"N/A"
-            return my_list
-
         lldp = {}
         lldp_neighbors = self.get_lldp_neighbors()
 
@@ -501,13 +491,10 @@ class IOSDriver(NetworkDriver):
             lldp_fields = [port_id, port_description, chassis_id, system_name, system_description,
                            system_capabilities, enabled_capabilities, remote_address]
 
-            # Check length of each list
+            # re.findall will return a list. Make sure same number of entries always returned.
             for test_list in lldp_fields:
-                if len(test_list) > number_entries:
+                if len(test_list) != number_entries:
                     raise ValueError("Failure processing show lldp neighbors detail")
-
-            # Pad any missing entries with "N/A"
-            lldp_fields = [pad_list_entries(field, number_entries) for field in lldp_fields]
 
             # Standardize the fields
             port_id, port_description, chassis_id, system_name, system_description, \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [pylama]
 linters = mccabe,pep8,pyflakes
 ignore = D203,C901
+skip = build/*,.tox/*
 
 [pylama:pep8]
 max_line_length = 100


### PR DESCRIPTION
The padding function was broken.

Also it is better to just generate an exception in this case (as it indicates something went wrong in the parsing). 

Also add support for interface argument per getter definition.