### PR TITLE
Update lldp detail regex

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -486,15 +486,13 @@ class IOSDriver(NetworkDriver):
 
             local_port = interface
             port_id = re.findall(r"Port id: (.+)", output)
-            port_description = re.findall(r"Port Description: (.+)", output)
+            port_description = re.findall(r"Port Description(?:\s\-|:) (.+)", output)
             chassis_id = re.findall(r"Chassis id: (.+)", output)
             system_name = re.findall(r"System Name: (.+)", output)
             system_description = re.findall(r"System Description: \n(.+)", output)
             system_capabilities = re.findall(r"System Capabilities: (.+)", output)
             enabled_capabilities = re.findall(r"Enabled Capabilities: (.+)", output)
-            remote_address = re.findall(r"Management Addresses:\n    IP: (.+)", output)
-            if not remote_address:
-                remote_address = re.findall(r"Management Addresses:\n    Other: (.+)", output)
+            remote_address = re.findall(r"Management Addresses:\n    (?:IP:|Other:) (.+)", output)
             number_entries = len(port_id)
             lldp_fields = [port_id, port_description, chassis_id, system_name, system_description,
                            system_capabilities, enabled_capabilities, remote_address]

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -485,14 +485,15 @@ class IOSDriver(NetworkDriver):
                 return {}
 
             local_port = interface
-            port_id = re.findall(r"Port id: (.+)", output)
-            port_description = re.findall(r"Port Description(?:\s\-|:) (.+)", output)
-            chassis_id = re.findall(r"Chassis id: (.+)", output)
-            system_name = re.findall(r"System Name: (.+)", output)
-            system_description = re.findall(r"System Description: \n(.+)", output)
-            system_capabilities = re.findall(r"System Capabilities: (.+)", output)
-            enabled_capabilities = re.findall(r"Enabled Capabilities: (.+)", output)
-            remote_address = re.findall(r"Management Addresses:\n    (?:IP:|Other:) (.+)", output)
+            port_id = re.findall(r"Port id:\s+(.+)", output)
+            port_description = re.findall(r"Port Description(?:\s\-|:)\s+(.+)", output)
+            chassis_id = re.findall(r"Chassis id:\s+(.+)", output)
+            system_name = re.findall(r"System Name:\s+(.+)", output)
+            system_description = re.findall(r"System Description:\s*\n(.+)", output)
+            system_capabilities = re.findall(r"System Capabilities:\s+(.+)", output)
+            enabled_capabilities = re.findall(r"Enabled Capabilities:\s+(.+)", output)
+            remote_address = re.findall(r"Management Addresses:\n\s+(?:IP|Other)(?::\s+?)(.+)",
+                                        output)
             number_entries = len(port_id)
             lldp_fields = [port_id, port_description, chassis_id, system_name, system_description,
                            system_capabilities, enabled_capabilities, remote_address]

--- a/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/expected_result.json
+++ b/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/expected_result.json
@@ -1,0 +1,24 @@
+{
+    "GigabitEthernet1": [
+        {
+            "parent_interface": "N/A", 
+            "remote_chassis_id": "2cc2.603e.363b", 
+            "remote_port": "Management1", 
+            "remote_port_description": "not advertised", 
+            "remote_system_capab": "B,R", 
+            "remote_system_description": "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS", 
+            "remote_system_enable_capab": "B,R", 
+            "remote_system_name": "eos-spine1.ntc.com"
+        }, 
+        {
+            "parent_interface": "N/A", 
+            "remote_chassis_id": "0005.8671.58c0", 
+            "remote_port": "fxp0", 
+            "remote_port_description": "fxp0", 
+            "remote_system_capab": "B,R", 
+            "remote_system_description": "Juniper Networks, Inc. vmx internet router, kernel JUNOS 15.1F4.15, Build date: 2015-12-23 19:22:55 UTC Copyright (c) 1996-2015 Juniper Networks, Inc.", 
+            "remote_system_enable_capab": "B,R", 
+            "remote_system_name": "vmx1"
+        }
+    ]
+}

--- a/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/show_int_Gi1.txt
+++ b/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/show_int_Gi1.txt
@@ -1,0 +1,28 @@
+GigabitEthernet1 is up, line protocol is up 
+  Hardware is CSR vNIC, address is 2cc2.603f.437a (bia 2cc2.603f.437a)
+  Internet address is 10.0.0.51/24
+  MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec, 
+     reliability 198/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full Duplex, 1000Mbps, link type is auto, media type is RJ45
+  output flow-control is unsupported, input flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:07, output 00:00:18, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/375/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 1000 bits/sec, 1 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     3815699 packets input, 275467675 bytes, 0 no buffer
+     Received 0 broadcasts (0 IP multicasts)
+     0 runts, 0 giants, 0 throttles 
+     2610907 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     5249863 packets output, 384472234 bytes, 0 underruns
+     0 output errors, 0 collisions, 0 interface resets
+     11192 unknown protocol drops
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 pause output
+     0 output buffer failures, 0 output buffers swapped out

--- a/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/show_lldp_neighbors.txt
+++ b/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/show_lldp_neighbors.txt
@@ -1,0 +1,10 @@
+Capability codes:
+    (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+    (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+
+Device ID           Local Intf     Hold-time  Capability      Port ID
+eos-spine1.ntc.com  Gi1            120        B,R             Management1
+vmx1                Gi1            120        B,R             fxp0
+
+Total entries displayed: 2
+

--- a/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/show_lldp_neighbors_GigabitEthernet1_detail.txt
+++ b/test/unit/mocked_data/test_get_lldp_neighbors_detail/alternate/show_lldp_neighbors_GigabitEthernet1_detail.txt
@@ -1,0 +1,53 @@
+------------------------------------------------
+Local Intf: Gi1
+Chassis id: 2cc2.603e.363b
+Port id: Management1
+Port Description - not advertised
+System Name: eos-spine1.ntc.com
+
+System Description:
+Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS
+
+Time remaining: 95 seconds
+System Capabilities: B,R
+Enabled Capabilities: B,R
+Management Addresses:
+    Other: 2C FF 60 3E 36 3B 00
+Auto Negotiation - not supported
+Physical media capabilities - not advertised
+Media Attachment Unit type - not advertised
+Vlan ID: - not advertised
+
+------------------------------------------------
+Local Intf: Gi1
+Chassis id: 0005.8671.58c0
+Port id: fxp0
+Port Description: fxp0
+System Name: vmx1
+
+System Description:
+Juniper Networks, Inc. vmx internet router, kernel JUNOS 15.1F4.15, Build date: 2015-12-23 19:22:55 UTC Copyright (c) 1996-2015 Juniper Networks, Inc.
+
+Time remaining: 116 seconds
+System Capabilities: B,R
+Enabled Capabilities: B,R
+Management Addresses:
+    IP: 10.0.0.31
+    OID:
+        0.1.3.6.1.2.1.31.1.1.1.1.1.
+Auto Negotiation - supported, disabled
+Physical media capabilities:
+    1000baseT(FD)
+    1000baseX(FD)
+    1000baseX(HD)
+    Symm, Asym Pause(FD)
+    100base-TX(FD)
+    100base-TX(HD)
+    10base-T(FD)
+    10base-T(HD)
+Media Attachment Unit type - not advertised
+Vlan ID: - not advertised
+
+
+Total entries displayed: 2
+


### PR DESCRIPTION
Port description can have ' -' as delimiter instead of ':'
The findall between IP and other should happen in one check, otherwise it doesn't return both at the same time, when you have a mix. 

Test Data
```
csr1#show lldp neighbors GigabitEthernet 1 detail
------------------------------------------------
Local Intf: Gi1
Chassis id: 2cc2.603e.363b
Port id: Management1
Port Description - not advertised
System Name: eos-spine1.ntc.com

System Description:
Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS

Time remaining: 95 seconds
System Capabilities: B,R
Enabled Capabilities: B,R
Management Addresses:
    Other: 2C FF 60 3E 36 3B 00
Auto Negotiation - not supported
Physical media capabilities - not advertised
Media Attachment Unit type - not advertised
Vlan ID: - not advertised

------------------------------------------------
Local Intf: Gi1
Chassis id: 0005.8671.58c0
Port id: fxp0
Port Description: fxp0
System Name: vmx1

System Description:
Juniper Networks, Inc. vmx internet router, kernel JUNOS 15.1F4.15, Build date: 2015-12-23 19:22:55 UTC Copyright (c) 1996-2015 Juniper Networks, Inc.

Time remaining: 116 seconds
System Capabilities: B,R
Enabled Capabilities: B,R
Management Addresses:
    IP: 10.0.0.31
    OID:
        0.1.3.6.1.2.1.31.1.1.1.1.1.
Auto Negotiation - supported, disabled
Physical media capabilities:
    1000baseT(FD)
    1000baseX(FD)
    1000baseX(HD)
    Symm, Asym Pause(FD)
    100base-TX(FD)
    100base-TX(HD)
    10base-T(FD)
    10base-T(HD)
Media Attachment Unit type - not advertised
Vlan ID: - not advertised


Total entries displayed: 2

csr1#
```

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
