### PR TITLE
Allow parallel requests over the same SSH session

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -146,7 +146,7 @@ class IOSDriver(NetworkDriver):
                and not self._timeout_exceeded(start, 'Waiting to acquire the SSH session!')):
                 # will wait here till the SSH channel is free again and ready to receive requests
                 # if stays too much, _timeout_exceeded will raise CommandTimeoutException
-                pass  # do nothing, just wait
+                time.sleep(0.01)
         return True  # ready to go now
 
     def _unlock_ssh_session(self):

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -26,7 +26,9 @@ from threading import Lock
 from netmiko import ConnectHandler, FileTransfer, InLineTransfer
 from netmiko import __version__ as netmiko_version
 from napalm_base.base import NetworkDriver
-from napalm_base.exceptions import ReplaceConfigException, MergeConfigException, CommandTimeoutException
+from napalm_base.exceptions import MergeConfigException
+from napalm_base.exceptions import ReplaceConfigException
+from napalm_base.exceptions import CommandTimeoutException
 from napalm_base.utils import py23_compat
 import napalm_base.constants as C
 import napalm_base.helpers
@@ -141,8 +143,8 @@ class IOSDriver(NetworkDriver):
 
     def _lock_ssh_session(self, start):
         while (not self._ssh_session_locker.acquire(False)
-            and not self._timeout_exceeded(start, 'Waiting to acquire the SSH session!')):
-                # will wait here till the SSH channel is free again and ready to receive new requests
+               and not self._timeout_exceeded(start, 'Waiting to acquire the SSH session!')):
+                # will wait here till the SSH channel is free again and ready to receive requests
                 # if stays too much, _timeout_exceeded will raise CommandTimeoutException
                 pass  # do nothing, just wait
         return True  # ready to go now


### PR DESCRIPTION
Opening this PR for initial discussion. Ref: #119

Introducing a simple mutex mechanism to virtually lock the
channel in the current SSH session. During this time, all
subsequent requests will be waiting to be served.
If there are any requests waiting more than the timeout
specified during open(), CommandTimeoutException is raised.
Request from other SSH sessions are not affected by this.
This should not affect at all the existing behaviour,
but it will widen the scope of the library.


I have tested on a 2811 and I confirm it works as expected.