### PR TITLE
Add commit confirmed feature

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -387,11 +387,15 @@ class IOSDriver(NetworkDriver):
                 merge_error = "Configuration merge failed; automatic rollback attempted"
                 raise MergeConfigException(merge_error)
 
-        # Save config to startup (both replace and merge)
-        output += self.device.send_command_expect("write mem")
+        if not confirmed:
+            # Save config to startup (both replace and merge)
+            output += self.device.send_command_expect("write mem")
 
     def commit_confirm(self):
+        # Confirm replacement of running-config with a new config file
         output = self.device.send_command_expect('configure confirm')
+        # Save config to startup (both replace and merge)
+        output += self.device.send_command_expect("write mem")
 
     def discard_config(self):
         """Set candidate_cfg to current running-config. Erase the merge_cfg file."""

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -355,7 +355,7 @@ class IOSDriver(NetworkDriver):
             if self.auto_rollback_on_error:
                 cmd = 'configure replace {} force revert trigger error'.format(cfg_file)
             elif confirmed:
-                cmd = 'configure replace {} force time {}'.format(cfg_file, confirmed)
+                cmd = 'configure replace bootflash:{} force time {}'.format(cfg_file, confirmed)
             else:
                 cmd = 'configure replace {} force'.format(cfg_file)
             output = self._commit_hostname_handler(cmd)
@@ -379,7 +379,8 @@ class IOSDriver(NetworkDriver):
                 cmd = 'copy running-config {}'.format(self.candidate_cfg)
                 output += self.device.send_command_expect(cmd)
                 # Replace with the candidate and force rollback if not confirmed
-                cmd = 'configure replace {} force time {}'.format(self.candidate_cfg, confirmed)
+                cmd = 'configure replace bootflash:{} force time {}'.format(self.candidate_cfg,
+                                                                            confirmed)
                 output += self.device.send_command_expect(cmd)
             self._enable_confirm()
             if 'Invalid input detected' in output:


### PR DESCRIPTION
Based on the suggestions from https://github.com/napalm-automation/napalm-ios/issues/121, submitting this changes to try an implementation for commit confirmed.

For load_merge, when confirmed is required, a candidate config file is saved on the flash that is used afterwards to replace and schedule the rollback time.