### PR TITLE
Modifications to get_optics to survive from N/A output power value

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -592,6 +592,13 @@ class IOSDriver(NetworkDriver):
             port_detail['physical_channels'] = {}
             port_detail['physical_channels']['channel'] = []
 
+            # If interface is shutdown it returns "N/A" as output power.
+            # Converting that to -40.0 float
+            try:
+                float(output_power)
+            except ValueError:
+                output_power = -40.0
+
             # Defaulting avg, min, max values to 0.0 since device does not
             # return these values
             optic_states = {

--- a/test/unit/mocked_data/test_get_optics/interface_shutdown/expected_result.json
+++ b/test/unit/mocked_data/test_get_optics/interface_shutdown/expected_result.json
@@ -1,0 +1,56 @@
+{
+	"TenGigabitEthernet1/0/1": {
+		"physical_channels": {
+			"channel": [{
+				"index": 0,
+				"state": {
+					"output_power": {
+						"max": 0.0,
+						"avg": 0.0,
+						"instant": -2.0,
+						"min": 0.0
+					},
+					"laser_bias_current": {
+						"max": 0.0,
+						"avg": 0.0,
+						"instant": 0.0,
+						"min": 0.0
+					},
+					"input_power": {
+						"max": 0.0,
+						"avg": 0.0,
+						"instant": -3.5,
+						"min": 0.0
+					}
+				}
+			}]
+		}
+	},
+	"TenGigabitEthernet2/0/1": {
+		"physical_channels": {
+			"channel": [{
+				"index": 0, 
+				"state": {
+					"output_power": {
+						"max": 0.0,
+						"avg": 0.0,
+						"instant": -40.0,
+						"min": 0.0
+					},
+					"laser_bias_current": {
+						"max": 0.0,
+						"avg": 0.0,
+						"instant": 0.0,
+						"min": 0.0
+					}, 
+					"input_power": {
+						"max": 0.0, 
+						"avg": 0.0, 
+						"instant": -40.0,
+						"min": 0.0
+					}
+				}
+			}]
+		}
+	}
+}

--- a/test/unit/mocked_data/test_get_optics/interface_shutdown/show_int_Te1_0_1.txt
+++ b/test/unit/mocked_data/test_get_optics/interface_shutdown/show_int_Te1_0_1.txt
@@ -1,0 +1,29 @@
+TenGigabitEthernet1/0/1 is up, line protocol is up (connected) 
+  Hardware is Ten Gigabit Ethernet, address is 0042.5a67.0e9b (bia 0042.5a67.0e9b)
+  Description: Uplink-to-DSW1
+  MTU 1500 bytes, BW 10000000 Kbit/sec, DLY 10 usec, 
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not set
+  Full-duplex, 10Gb/s, link type is auto, media type is SFP-10GBase-LRM
+  input flow-control is off, output flow-control is unsupported 
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:02, output 00:00:04, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 61000 bits/sec, 52 packets/sec
+  5 minute output rate 59000 bits/sec, 63 packets/sec
+     13525429 packets input, 1636789604 bytes, 0 no buffer
+     Received 2388654 broadcasts (578107 multicasts)
+     0 runts, 0 giants, 0 throttles 
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 578107 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     7831375 packets output, 870124569 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 unknown protocol drops
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 pause output
+     0 output buffer failures, 0 output buffers swapped out

--- a/test/unit/mocked_data/test_get_optics/interface_shutdown/show_int_Te2_0_1.txt
+++ b/test/unit/mocked_data/test_get_optics/interface_shutdown/show_int_Te2_0_1.txt
@@ -1,0 +1,29 @@
+TenGigabitEthernet2/0/1 is up, line protocol is up (connected) 
+  Hardware is Ten Gigabit Ethernet, address is 0042.5a8d.d91b (bia 0042.5a8d.d91b)
+  Description: Uplink-to-DSW2
+  MTU 1500 bytes, BW 10000000 Kbit/sec, DLY 10 usec, 
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not set
+  Full-duplex, 10Gb/s, link type is auto, media type is SFP-10GBase-LRM
+  input flow-control is off, output flow-control is unsupported 
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:29, output 00:00:01, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 187000 bits/sec, 135 packets/sec
+  5 minute output rate 181000 bits/sec, 113 packets/sec
+     21192627 packets input, 4732793131 bytes, 0 no buffer
+     Received 1625861 broadcasts (279957 multicasts)
+     0 runts, 0 giants, 0 throttles 
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 279957 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     27963853 packets output, 3954071411 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 unknown protocol drops
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 pause output
+     0 output buffer failures, 0 output buffers swapped out

--- a/test/unit/mocked_data/test_get_optics/interface_shutdown/show_interfaces_transceiver.txt
+++ b/test/unit/mocked_data/test_get_optics/interface_shutdown/show_interfaces_transceiver.txt
@@ -1,0 +1,11 @@
+If device is externally calibrated, only calibrated values are printed.
+++ : high alarm, +  : high warning, -  : low warning, -- : low alarm.
+NA or N/A: not applicable, Tx: transmit, Rx: receive.
+mA: milliamperes, dBm: decibels (milliwatts).
+
+                                 Optical   Optical
+           Temperature  Voltage  Tx Power  Rx Power
+Port       (Celsius)    (Volts)  (dBm)     (dBm)
+---------  -----------  -------  --------  --------
+Te1/0/1      34.6       3.29      -2.0      -3.5   
+Te2/0/1      34.3       3.28      N/A      -40.0   


### PR DESCRIPTION
Part of: https://github.com/napalm-automation/napalm-base/issues/237