### PR TITLE
Fix get_optic infinite value to 100

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -593,11 +593,11 @@ class IOSDriver(NetworkDriver):
             port_detail['physical_channels']['channel'] = []
 
             # If interface is shutdown it returns "N/A" as output power.
-            # Converting that to -40.0 float
+            # Converting that to -100.0 float
             try:
                 float(output_power)
             except ValueError:
-                output_power = -40.0
+                output_power = -100.0
 
             # Defaulting avg, min, max values to 0.0 since device does not
             # return these values

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
     ],
     url="https://github.com/napalm-automation/napalm-ios",
     include_package_data=True,
+    zip_safe=False,
     install_requires=reqs,
 )

--- a/test/unit/TestIOSDriver.py
+++ b/test/unit/TestIOSDriver.py
@@ -91,16 +91,16 @@ class TestConfigIOSDriver(unittest.TestCase, TestConfigNetworkDriver):
 
     def test_ios_only_gen_full_path(self):
         """Test gen_full_path() method."""
-        output = self.device.gen_full_path(self.device.candidate_cfg)
+        output = self.device._gen_full_path(self.device.candidate_cfg)
         self.assertEqual(output, self.device.dest_file_system + '/candidate_config.txt')
 
-        output = self.device.gen_full_path(self.device.rollback_cfg)
+        output = self.device._gen_full_path(self.device.rollback_cfg)
         self.assertEqual(output, self.device.dest_file_system + '/rollback_config.txt')
 
-        output = self.device.gen_full_path(self.device.merge_cfg)
+        output = self.device._gen_full_path(self.device.merge_cfg)
         self.assertEqual(output, self.device.dest_file_system + '/merge_config.txt')
 
-        output = self.device.gen_full_path(filename='running-config', file_system='system:')
+        output = self.device._gen_full_path(filename='running-config', file_system='system:')
         self.assertEqual(output, 'system:/running-config')
 
     def test_ios_only_check_file_exists(self):

--- a/test/unit/mocked_data/test_get_optics/interface_shutdown/expected_result.json
+++ b/test/unit/mocked_data/test_get_optics/interface_shutdown/expected_result.json
@@ -34,7 +34,7 @@
 					"output_power": {
 						"max": 0.0,
 						"avg": 0.0,
-						"instant": -40.0,
+						"instant": -100.0,
 						"min": 0.0
 					},
 					"laser_bias_current": {


### PR DESCRIPTION
Also includes a minor unit test fix and a fix to try to encourage setup.py not to create .egg files.