### PR TITLE
Modified infinite value of optical powers from -40 to -100 and added another unit test

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -581,9 +581,13 @@ class IOSDriver(NetworkDriver):
         for optics_entry in split_output.splitlines():
             # Example, Te1/0/1      34.6       3.29      -2.0      -3.5
             try:
-                int_brief, temperature, voltage, output_power, input_power = optics_entry.split()
+                split_list = optics_entry.split()
             except ValueError:
                 return {}
+
+            int_brief = split_list[0]
+            output_power = split_list[3]
+            input_power = split_list[4]
 
             port = self._expand_interface_name(int_brief)
 

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -593,28 +593,28 @@ class IOSDriver(NetworkDriver):
             port_detail['physical_channels']['channel'] = []
 
             # If interface is shutdown it returns "N/A" as output power.
-            # Converting that to -40.0 float
+            # Converting that to -100.0 float
             try:
                 float(output_power)
             except ValueError:
-                output_power = -40.0
+                output_power = -100.0
 
-            # Defaulting avg, min, max values to 0.0 since device does not
+            # Defaulting avg, min, max values to -100.0 since device does not
             # return these values
             optic_states = {
                 'index': 0,
                 'state': {
                     'input_power': {
-                        'instant': (float(input_power) if 'input_power' else 0.0),
-                        'avg': 0.0,
-                        'min': 0.0,
-                        'max': 0.0
+                        'instant': (float(input_power) if 'input_power' else -100.0),
+                        'avg': -100.0,
+                        'min': -100.0,
+                        'max': -100.0
                     },
                     'output_power': {
-                        'instant': (float(output_power) if 'output_power' else 0.0),
-                        'avg': 0.0,
-                        'min': 0.0,
-                        'max': 0.0
+                        'instant': (float(output_power) if 'output_power' else -100.0),
+                        'avg': -100.0,
+                        'min': -100.0,
+                        'max': -100.0
                     },
                     'laser_bias_current': {
                         'instant': 0.0,

--- a/test/unit/mocked_data/test_get_optics/interface_shutdown/expected_result.json
+++ b/test/unit/mocked_data/test_get_optics/interface_shutdown/expected_result.json
@@ -5,10 +5,10 @@
 				"index": 0,
 				"state": {
 					"output_power": {
-						"max": 0.0,
-						"avg": 0.0,
+						"max": -100.0,
+						"avg": -100.0,
 						"instant": -2.0,
-						"min": 0.0
+						"min": -100.0
 					},
 					"laser_bias_current": {
 						"max": 0.0,
@@ -17,10 +17,10 @@
 						"min": 0.0
 					},
 					"input_power": {
-						"max": 0.0,
-						"avg": 0.0,
+						"max": -100.0,
+						"avg": -100.0,
 						"instant": -3.5,
-						"min": 0.0
+						"min": -100.0
 					}
 				}
 			}]
@@ -32,10 +32,10 @@
 				"index": 0, 
 				"state": {
 					"output_power": {
-						"max": 0.0,
-						"avg": 0.0,
-						"instant": -40.0,
-						"min": 0.0
+						"max": -100.0,
+						"avg": -100.0,
+						"instant": -100.0,
+						"min": -100.0
 					},
 					"laser_bias_current": {
 						"max": 0.0,
@@ -44,10 +44,10 @@
 						"min": 0.0
 					}, 
 					"input_power": {
-						"max": 0.0, 
-						"avg": 0.0, 
+						"max": -100.0, 
+						"avg": -100.0, 
 						"instant": -40.0,
-						"min": 0.0
+						"min": -100.0
 					}
 				}
 			}]

--- a/test/unit/mocked_data/test_get_optics/low_rx_power/expected_result.json
+++ b/test/unit/mocked_data/test_get_optics/low_rx_power/expected_result.json
@@ -1,0 +1,29 @@
+{
+	"GigabitEthernet0/11": {
+		"physical_channels": {
+			"channel": [{
+				"index": 0,
+				"state": {
+					"output_power": {
+						"max": -100.0,
+						"avg": -100.0,
+						"instant": -6.8,
+						"min": -100.0
+					},
+					"laser_bias_current": {
+						"max": 0.0,
+						"avg": 0.0,
+						"instant": 0.0,
+						"min": 0.0
+					},
+					"input_power": {
+						"max": -100.0,
+						"avg": -100.0,
+						"instant": -27.4,
+						"min": -100.0
+					}
+				}
+			}]
+		}
+	}
+}

--- a/test/unit/mocked_data/test_get_optics/low_rx_power/show_int_Gi0_11.txt
+++ b/test/unit/mocked_data/test_get_optics/low_rx_power/show_int_Gi0_11.txt
@@ -1,0 +1,29 @@
+GigabitEthernet0/11 is up, line protocol is up (connected) 
+  Hardware is Gigabit Ethernet, address is 00da.5567.3e8b (bia 00da.5567.3e8b)
+  Description: Uplink
+  MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec, 
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not set
+  Full-duplex, 1000Mb/s, link type is auto, media type is 1000BaseLX SFP
+  input flow-control is off, output flow-control is unsupported 
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:01, output 00:00:26, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 41000 bits/sec, 68 packets/sec
+  5 minute output rate 40000 bits/sec, 66 packets/sec
+     285486634 packets input, 21249719318 bytes, 0 no buffer
+     Received 5577815 broadcasts (2476464 multicasts)
+     0 runts, 0 giants, 0 throttles 
+     2896 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 2476464 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     298435968 packets output, 78061625290 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 unknown protocol drops
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 pause output
+     0 output buffer failures, 0 output buffers swapped out

--- a/test/unit/mocked_data/test_get_optics/low_rx_power/show_interfaces_transceiver.txt
+++ b/test/unit/mocked_data/test_get_optics/low_rx_power/show_interfaces_transceiver.txt
@@ -1,0 +1,10 @@
+If device is externally calibrated, only calibrated values are printed.
+++ : high alarm, +  : high warning, -  : low warning, -- : low alarm.
+NA or N/A: not applicable, Tx: transmit, Rx: receive.
+mA: milliamperes, dBm: decibels (milliwatts).
+
+                                 Optical   Optical
+           Temperature  Voltage  Tx Power  Rx Power
+Port       (Celsius)    (Volts)  (dBm)     (dBm)
+---------  -----------  -------  --------  --------
+Gi0/11       24.0       3.22      -6.8     -27.4 --

--- a/test/unit/mocked_data/test_get_optics/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_optics/normal/expected_result.json
@@ -5,10 +5,10 @@
 				"index": 0,
 				"state": {
 					"output_power": {
-						"max": 0.0,
-						"avg": 0.0,
+						"max": -100.0,
+						"avg": -100.0,
 						"instant": -2.0,
-						"min": 0.0
+						"min": -100.0
 					},
 					"laser_bias_current": {
 						"max": 0.0,
@@ -17,10 +17,10 @@
 						"min": 0.0
 					},
 					"input_power": {
-						"max": 0.0,
-						"avg": 0.0,
+						"max": -100.0,
+						"avg": -100.0,
 						"instant": -3.5,
-						"min": 0.0
+						"min": -100.0
 					}
 				}
 			}]
@@ -32,10 +32,10 @@
 				"index": 0, 
 				"state": {
 					"output_power": {
-						"max": 0.0,
-						"avg": 0.0,
+						"max": -100.0,
+						"avg": -100.0,
 						"instant": -2.0,
-						"min": 0.0
+						"min": -100.0
 					},
 					"laser_bias_current": {
 						"max": 0.0,
@@ -44,10 +44,10 @@
 						"min": 0.0
 					}, 
 					"input_power": {
-						"max": 0.0, 
-						"avg": 0.0, 
+						"max": -100.0, 
+						"avg": -100.0, 
 						"instant": -2.5,
-						"min": 0.0
+						"min": -100.0
 					}
 				}
 			}]


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>

This was made because of current infinite value of -40.0 (or 0.0 in some cases) can be completely valid value for optical power. -100.0 is far enough for anyone to mistakenly think as valid value.