### PR TITLE
Add SSH keepalive

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -70,13 +70,12 @@ class IOSDriver(NetworkDriver):
         self.dest_file_system = optional_args.get('dest_file_system', None)
         self.auto_rollback_on_error = optional_args.get('auto_rollback_on_error', True)
 
-        self.keepalive = optional_args.get('keepalive', 30)
-
         # Netmiko possible arguments
         netmiko_argument_map = {
             'port': None,
             'secret': '',
             'verbose': False,
+            'keepalive': 30,
             'global_delay_factor': 1,
             'use_keys': False,
             'key_file': None,
@@ -118,7 +117,6 @@ class IOSDriver(NetworkDriver):
                                      username=self.username,
                                      password=self.password,
                                      **self.netmiko_optional_args)
-        self.device.remote_conn.transport.set_keepalive(self.keepalive)
         # ensure in enable mode
         self.device.enable()
         if not self.dest_file_system:

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -70,6 +70,8 @@ class IOSDriver(NetworkDriver):
         self.dest_file_system = optional_args.get('dest_file_system', None)
         self.auto_rollback_on_error = optional_args.get('auto_rollback_on_error', True)
 
+        self.keepalive = optional_args.get('keepalive', 30)
+
         # Netmiko possible arguments
         netmiko_argument_map = {
             'port': None,
@@ -116,6 +118,7 @@ class IOSDriver(NetworkDriver):
                                      username=self.username,
                                      password=self.password,
                                      **self.netmiko_optional_args)
+        self.device.remote_conn.transport.set_keepalive(self.keepalive)
         # ensure in enable mode
         self.device.enable()
         if not self.dest_file_system:


### PR DESCRIPTION
Under https://github.com/napalm-automation/napalm-junos/pull/147 an user has added the keepalive optional argument. We have then thought that it would be good to leverage this option for other SSH-based drivers.
Opening this PR to add the new keepalive optional arg.