### PR TITLE
Capture generic errors when doing a commit/replace

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -362,7 +362,7 @@ class IOSDriver(NetworkDriver):
             if ('Failed to apply command' in output) or \
                ('original configuration has been successfully restored' in output) or \
                ('Error' in output):
-                msg = "Candidate config could not be applied\n{}".format(output)"
+                msg = "Candidate config could not be applied\n{}".format(output)
                 raise ReplaceConfigException(msg)
             elif '%Please turn config archive on' in output:
                 msg = "napalm-ios replace() requires Cisco 'archive' feature to be enabled."

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -360,8 +360,9 @@ class IOSDriver(NetworkDriver):
                 cmd = 'configure replace {} force'.format(cfg_file)
             output = self._commit_hostname_handler(cmd)
             if ('Failed to apply command' in output) or \
-               ('original configuration has been successfully restored' in output):
-                raise ReplaceConfigException("Candidate config could not be applied")
+               ('original configuration has been successfully restored' in output) or \
+               ('Error' in output):
+                raise ReplaceConfigException("Candidate config could not be applied\n{}".format(output))
             elif '%Please turn config archive on' in output:
                 msg = "napalm-ios replace() requires Cisco 'archive' feature to be enabled."
                 raise ReplaceConfigException(msg)

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -362,7 +362,8 @@ class IOSDriver(NetworkDriver):
             if ('Failed to apply command' in output) or \
                ('original configuration has been successfully restored' in output) or \
                ('Error' in output):
-                raise ReplaceConfigException("Candidate config could not be applied\n{}".format(output))
+                msg = "Candidate config could not be applied\n{}".format(output)"
+                raise ReplaceConfigException(msg)
             elif '%Please turn config archive on' in output:
                 msg = "napalm-ios replace() requires Cisco 'archive' feature to be enabled."
                 raise ReplaceConfigException(msg)


### PR DESCRIPTION
I realized that some generic errors like this one weren't being captured:

```
    cannot install config: Candidate config could not be applied
    Error: received error code 5 when looking for missing lines

    The rollback configlet from the last pass is listed below:
    ********
    !List of Rollback Commands:
    no end
    interface GigabitEthernet3
     no ipv6 address 2001:DB8:CAF3:2::1/64
     no negotiation auto
     no description Link2;
    interface GigabitEthernet2
     no ipv6 address 2001:DB8:CAF3:1::1/64
     no negotiation auto
     no description Link1;
    interface Loopback0
     no ipv6 address 2001:DB8:B33F::101/128
     no description Loopback interface;
    no username hacker nopassword
    archive
     no write-memory
     no path bootflash:archive
    no boot-end-marker

    no boot-start-marker

    archive
      path bootflash:archive
      write-memory
    interface Loopback0
      description Loopback interface;
      ipv6 address 2001:DB8:B33F::101/128
      no shutdown
    interface GigabitEthernet2
      description Link1;
      ipv6 address 2001:DB8:CAF3:1::1/64
      no shutdown
    ********


    Rollback aborted after 1 passes
```

What that error actually means or why it's triggered I don't know. It also appends the error to the  exception message.