### PR TITLE
Reconnect on socket.error or EOF

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -25,7 +25,9 @@ import socket
 from netmiko import ConnectHandler, FileTransfer, InLineTransfer
 from netmiko import __version__ as netmiko_version
 from napalm_base.base import NetworkDriver
-from napalm_base.exceptions import ReplaceConfigException, MergeConfigException
+from napalm_base.exceptions import ReplaceConfigException, MergeConfigException, \
+            ConnectionClosedException
+
 from napalm_base.utils import py23_compat
 import napalm_base.constants as C
 import napalm_base.helpers
@@ -144,9 +146,8 @@ class IOSDriver(NetworkDriver):
             else:
                 output = self.device.send_command(command)
             return self._send_command_postprocess(output)
-        except (socket.error, EOFError):
-            self.open()
-            return self._send_command(command)
+        except (socket.error, EOFError) as e:
+            raise ConnectionClosedException(str(e))
 
     def is_alive(self):
         """Returns a flag with the state of the SSH connection."""

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -144,7 +144,7 @@ class IOSDriver(NetworkDriver):
             else:
                 output = self.device.send_command(command)
             return self._send_command_postprocess(output)
-        except socket.error:
+        except (socket.error, EOFError):
             self.open()
             return self._send_command(command)
 


### PR DESCRIPTION
A long running connection to a remote device with `exec-timeout` configured will cause the socket to go EOF.  If a subsequent write to that socket is attempted, paramiko returns `socket.error`.  This PR will reopen a closed socket and re-send the command which was attempted.