### PR TITLE
Send null byte when is_alive is polled

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 import re
 import os
 import uuid
+import socket
 import tempfile
 
 from netmiko import ConnectHandler, FileTransfer, InLineTransfer

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -145,6 +145,18 @@ class IOSDriver(NetworkDriver):
 
     def is_alive(self):
         """Returns a flag with the state of the SSH connection."""
+        null = chr(0)
+        try:
+            # Try sending ASCII null byte to maintain
+            #   the connection alive
+            self.device.send_command(null)
+        except (socket.error, EOFError):
+            # If unable to send, we can tell for sure
+            #   that the connection is unusable,
+            #   hence return False.
+            return {
+                'is_alive': False
+            }
         return {
             'is_alive': self.device.remote_conn.transport.is_active()
         }


### PR DESCRIPTION
As discussed with David B. under
https://github.com/napalm-automation/napalm-base/pull/249,
although it may be ambiguous that this method also executes
an action, it's safer to determine the real status of the
connection.

The paramiko flag is unreliable and it can return True
even if the connection is actually unusable.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
