### PR TITLE
Fixing lint issue with socket import

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -973,11 +973,12 @@ class IOSDriver(NetworkDriver):
                 speed_match = re.search(speed_regex, line)
                 speed = speed_match.groups()[0]
                 speedformat = speed_match.groups()[1]
-                speed = int(speed)
+                speed = float(speed)
                 if speedformat.startswith('Kb'):
-                    speed /= 1000
+                    speed = speed / 1000.0
                 elif speedformat.startswith('Gb'):
-                    speed *= 1000
+                    speed = speed * 1000
+                speed = int(round(speed))
 
                 if interface == '':
                     raise ValueError("Interface attributes were \

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -21,7 +21,6 @@ import os
 import uuid
 import socket
 import tempfile
-import socket
 import copy
 
 from netmiko import ConnectHandler, FileTransfer, InLineTransfer


### PR DESCRIPTION
There were two:

```
import socket
```

statements. This is causing pylama to fail.