### PR TITLE
fix 4500 multicast

### DIFF
--- a/test/unit/mocked_data/test_get_mac_address_table/4500_format/expected_result.json
+++ b/test/unit/mocked_data/test_get_mac_address_table/4500_format/expected_result.json
@@ -1,1 +1,128 @@
-[{"moves": -1, "interface": "Port-channel1", "vlan": 1, "static": false, "mac": "30:A3:30:A3:A1:C3", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Port-channel1", "vlan": 99, "static": false, "mac": "30:A3:30:A3:A1:C4", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Port-channel1", "vlan": 99, "static": false, "mac": "30:A3:30:A3:A1:C5", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Port-channel1", "vlan": 99, "static": false, "mac": "30:A3:30:A3:A1:C6", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Port-channel1", "vlan": 99, "static": false, "mac": "30:A3:30:A3:A1:C7", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Port-channel1", "vlan": 99, "static": false, "mac": "30:A3:30:A3:A1:C8", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Port-channel1", "vlan": 99, "static": false, "mac": "30:A3:30:A3:A1:C9", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Port-channel1", "vlan": 99, "static": false, "mac": "30:A3:30:A3:A1:CA", "active": true, "last_move": -1.0}, {"moves": -1, "interface": "Po1", "vlan": 1, "static": true, "mac": "01:00:0C:CC:CC:CE", "active": false, "last_move": -1.0}, {"moves": -1, "interface": "Po1", "vlan": 1, "static": true, "mac": "FF:FF:FF:FF:FF:FF", "active": false, "last_move": -1.0}, {"moves": -1, "interface": "", "vlan": 39, "static": true, "mac": "FF:FF:FF:FF:FF:FF", "active": false, "last_move": -1.0}]
+[
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 1,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:C3",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 99,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:C4",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 99,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:C5",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 99,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:C6",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 99,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:C7",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 99,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:C8",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 99,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:C9",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Port-channel1",
+    "vlan": 99,
+    "static": false,
+    "mac": "30:A3:30:A3:A1:CA",
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Po1",
+    "vlan": 1,
+    "static": true,
+    "mac": "01:00:0C:CC:CC:CE",
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Po1",
+    "vlan": 1,
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Gi10/31",
+    "vlan": 39,
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Gi10/32",
+    "vlan": 39,
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "",
+    "vlan": 39,
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "moves": -1,
+    "interface": "Po1",
+    "vlan": 39,
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "active": false,
+    "last_move": -1
+  }
+]

--- a/test/unit/mocked_data/test_get_mac_address_table/4500_format2/expected_result.json
+++ b/test/unit/mocked_data/test_get_mac_address_table/4500_format2/expected_result.json
@@ -1,0 +1,227 @@
+[
+  {
+    "vlan": 1,
+    "interface": "Port-channel21",
+    "static": false,
+    "mac": "00:11:21:E4:87:10",
+    "moves": -1,
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "vlan": 1,
+    "interface": "",
+    "static": true,
+    "mac": "00:12:DA:F7:0C:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 1,
+    "interface": "Port-channel21",
+    "static": false,
+    "mac": "00:17:94:15:EE:C0",
+    "moves": -1,
+    "active": true,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "GigabitEthernet3/15",
+    "static": true,
+    "mac": "00:04:F2:FE:7F:95",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "GigabitEthernet2/47",
+    "static": true,
+    "mac": "00:04:F2:FE:82:DA",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 1,
+    "interface": "Po21",
+    "static": true,
+    "mac": "01:00:0C:CC:CC:CE",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 1,
+    "interface": "",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 1,
+    "interface": "Po21",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/4",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/5",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/8",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/11",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/12",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/13",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/19",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/41",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/42",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/43",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi2/47",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi3/10",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi3/15",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 11,
+    "interface": "Gi3/16",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 24,
+    "interface": "Po21",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 27,
+    "interface": "Gi3/30",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  },
+  {
+    "vlan": 27,
+    "interface": "Po21",
+    "static": true,
+    "mac": "FF:FF:FF:FF:FF:FF",
+    "moves": -1,
+    "active": false,
+    "last_move": -1
+  }
+]

--- a/test/unit/mocked_data/test_get_mac_address_table/4500_format2/show_mac_address_table.txt
+++ b/test/unit/mocked_data/test_get_mac_address_table/4500_format2/show_mac_address_table.txt
@@ -1,0 +1,19 @@
+Unicast Entries
+ vlan   mac address     type        protocols               port
+-------+---------------+--------+---------------------+--------------------
+   1    0011.21e4.8710   dynamic ip,assigned,other     Port-channel21
+   1    0012.daf7.0cff    static ip,ipx,assigned,other Switch
+   1    0017.9415.eec0   dynamic ip,assigned           Port-channel21
+  11    0004.f2fe.7f95    static ip,ipx,assigned,other GigabitEthernet3/15
+  11    0004.f2fe.82da    static ip,ipx,assigned,other GigabitEthernet2/47
+
+Multicast Entries
+ vlan    mac address     type    ports
+-------+---------------+-------+--------------------------------------------
+   1    0100.0ccc.ccce   system Po21
+   1    ffff.ffff.ffff   system Switch,Po21
+  11    ffff.ffff.ffff   system Gi2/4,Gi2/5,Gi2/8,Gi2/11,Gi2/12,Gi2/13,Gi2/19
+                                Gi2/41,Gi2/42,Gi2/43,Gi2/47,Gi3/10,Gi3/15
+                                Gi3/16
+  24    ffff.ffff.ffff   system Po21
+  27    ffff.ffff.ffff   system Gi3/30,Po21


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>

I noticed issue: #127 and realized it was pretty much the same issue with the 6500's. Adjusted the 4500 output as well, since it was null'ing out the similar comma delimited line since it had the word "switch" in it. 