### PR TITLE
Disable SCP server after tranfer file to device

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -504,7 +504,8 @@ class IOSDriver(NetworkDriver):
 
             # Transfer file
             transfer.transfer_file()
-
+            if enable_scp:
+                transfer.disable_scp()
             # Compares MD5 between local-remote files
             if transfer.verify_file():
                 msg = "File successfully transferred to remote device"


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
To avoid unnecessary commands being left after deployment, we'd disable scp server before close connection.
This is an enhancement for issue#174