### PR TITLE
fix bug when bgp is not active

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -1160,9 +1160,9 @@ class IOSDriver(NetworkDriver):
         # get summary output from device
         cmd_bgp_all_sum = 'show bgp all summary'
         summary_output = self._send_command(cmd_bgp_all_sum).strip()
-        
+
         # if BGP is not active, there are no neighbors
-        if 'BGP not active' in summary_output:
+        if not summary_output or 'BGP not active' in summary_output:
             return {'global': {}}
 
         # get neighbor output from device

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -1160,6 +1160,10 @@ class IOSDriver(NetworkDriver):
         # get summary output from device
         cmd_bgp_all_sum = 'show bgp all summary'
         summary_output = self._send_command(cmd_bgp_all_sum).strip()
+        
+        # if BGP is not active, there are no neighbors
+        if 'BGP not active' in summary_output:
+            return {'global': {}}
 
         # get neighbor output from device
         neighbor_output = ''


### PR DESCRIPTION
Getter get_bgp_neighbors FIX:

When BGP is not active on an IOS device, the output of "'show bgp all summary" is "% BGP not active".
router_id is set to None and summary_data is an empty list.
None cannot be converted to a netaddr.IPAddress instance and we get the following exception:

edit 2nd commit: when BGP is active, but there are no neighbors configured, summary_output is empty and we get the same exception

  File "C:\Users\minto\Desktop\Napalm dev\napalm-ios\napalm_ios\ios.py", line 1330, in get_bgp_neighbors
    router_id = napalm_base.helpers.ip(router_id, version=4)
  File "C:\Users\minto\Desktop\Apps\Pyzo\pyzo2015a\lib\site-packages\napalm_base\helpers.py", line 245, in ip
    addr_obj = IPAddress(addr)
  File "C:\Users\minto\Desktop\Apps\Pyzo\pyzo2015a\lib\site-packages\netaddr\ip\__init__.py", line 306, in __init__
    'address from %r' % addr)
netaddr.core.AddrFormatError: failed to detect a valid IP address from None
