### PR TITLE
set domain_name value beforehand in get_facts

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -861,7 +861,7 @@ class IOSDriver(NetworkDriver):
         # default values.
         vendor = u'Cisco'
         uptime = -1
-        serial_number, fqdn, os_version, hostname = (u'Unknown', u'Unknown', u'Unknown', u'Unknown')
+        serial_number, fqdn, os_version, hostname, domain_name = (u'Unknown',)*5
 
         # obtain output from device
         show_ver = self._send_command('show version')
@@ -890,7 +890,6 @@ class IOSDriver(NetworkDriver):
                 _, os_version = line.split("IOS (tm) ")
                 os_version = os_version.strip()
 
-        domain_name = 'not set'
         # Determine domain_name and fqdn
         for line in show_hosts.splitlines():
             if 'Default domain' in line:

--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -890,6 +890,7 @@ class IOSDriver(NetworkDriver):
                 _, os_version = line.split("IOS (tm) ")
                 os_version = os_version.strip()
 
+        domain_name = 'not set'
         # Determine domain_name and fqdn
         for line in show_hosts.splitlines():
             if 'Default domain' in line:

--- a/test/unit/mocked_data/test_get_facts/empty 'show hosts'/expected_result.json
+++ b/test/unit/mocked_data/test_get_facts/empty 'show hosts'/expected_result.json
@@ -1,0 +1,10 @@
+{
+	"os_version": "C2960 Software (C2960-LANBASEK9-M), Version 15.0(2)SE4, RELEASE SOFTWARE (fc1)",
+	"uptime": 16676160,
+	"interface_list": ["Vlan1", "Vlan20", "Vlan40", "Vlan41", "GigabitEthernet0/1", "GigabitEthernet0/2", "GigabitEthernet0/3", "GigabitEthernet0/4", "GigabitEthernet0/5", "GigabitEthernet0/6", "GigabitEthernet0/7", "GigabitEthernet0/8", "Port-channel1"],
+	"vendor": "Cisco",
+	"serial_number": "FOC1308V5NB",
+	"model": "WS-C2960G-8TC-L",
+	"hostname": "NS2903-ASW-01",
+	"fqdn": "Unknown"
+}

--- a/test/unit/mocked_data/test_get_facts/empty 'show hosts'/show_ip_interface_brief.txt
+++ b/test/unit/mocked_data/test_get_facts/empty 'show hosts'/show_ip_interface_brief.txt
@@ -1,0 +1,14 @@
+Interface              IP-Address      OK? Method Status                Protocol
+Vlan1                  unassigned      YES NVRAM  administratively down down
+Vlan20                 172.29.50.3     YES NVRAM  up                    up
+Vlan40                 unassigned      YES unset  up                    up
+Vlan41                 172.29.52.34    YES NVRAM  up                    up
+GigabitEthernet0/1     unassigned      YES unset  up                    up
+GigabitEthernet0/2     unassigned      YES unset  up                    up
+GigabitEthernet0/3     unassigned      YES unset  up                    up
+GigabitEthernet0/4     unassigned      YES unset  down                  down
+GigabitEthernet0/5     unassigned      YES unset  up                    up
+GigabitEthernet0/6     unassigned      YES unset  up                    up
+GigabitEthernet0/7     unassigned      YES unset  up                    up
+GigabitEthernet0/8     unassigned      YES unset  up                    up
+Port-channel1          unassigned      YES unset  administratively down down

--- a/test/unit/mocked_data/test_get_facts/empty 'show hosts'/show_version.txt
+++ b/test/unit/mocked_data/test_get_facts/empty 'show hosts'/show_version.txt
@@ -1,0 +1,59 @@
+Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(2)SE4, RELEASE SOFTWARE (fc1)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2013 by Cisco Systems, Inc.
+Compiled Wed 26-Jun-13 02:49 by prod_rel_team
+
+ROM: Bootstrap program is C2960 boot loader
+BOOTLDR: C2960 Boot Loader (C2960-HBOOT-M) Version 12.2(35r)SE2, RELEASE SOFTWARE (fc1)
+
+NS2903-ASW-01 uptime is 27 weeks, 4 days, 16 minutes
+System returned to ROM by power-on
+System restarted at 15:46:58 UTC Sun May 22 2016
+System image file is "flash:/c2960-lanbasek9-mz.150-2.SE4.bin"
+
+
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+
+cisco WS-C2960G-8TC-L (PowerPC405) processor (revision A0) with 65536K bytes of memory.
+Processor board ID FOC1308V5NB
+Last reset from power-on
+4 Virtual Ethernet interfaces
+8 Gigabit Ethernet interfaces
+The password-recovery mechanism is enabled.
+
+64K bytes of flash-simulated non-volatile configuration memory.
+Base ethernet MAC Address       : 00:24:F7:DD:77:00
+Motherboard assembly number     : 73-10613-08
+Power supply part number        : 341-0208-01
+Motherboard serial number       : FOC13083EGE
+Power supply serial number      : LIT1250099N
+Model revision number           : A0
+Motherboard revision number     : B0
+Model number                    : WS-C2960G-8TC-L
+System serial number            : FOC1308V5NB
+Top Assembly Part Number        : 800-28133-01
+Top Assembly Revision Number    : E0
+Version ID                      : V01
+CLEI Code Number                : COM7S00ARA
+Hardware Board Revision Number  : 0x01
+
+
+Switch Ports Model              SW Version            SW Image
+------ ----- -----              ----------            ----------
+*    1 8     WS-C2960G-8TC-L    15.0(2)SE4            C2960-LANBASEK9-M
+
+
+Configuration register is 0xF


### PR DESCRIPTION
in case the "show hosts" command doesn't return anything (empty string), we set domain_name value beforehand
This happened on "WS-C3850-24U running 16.3.1"

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
