### PR TITLE
Fix IPv6 regex issue

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -41,14 +41,15 @@ WEEK_SECONDS = 7 * DAY_SECONDS
 YEAR_SECONDS = 365 * DAY_SECONDS
 
 # STD REGEX PATTERNS
-IP_ADDR_REGEX = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+IP_ADDR_REGEX = "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
 IPV4_ADDR_REGEX = IP_ADDR_REGEX
-IPV6_ADDR_REGEX_1 = r"::"
-IPV6_ADDR_REGEX_2 = r"[0-9a-fA-F:]{1,39}::[0-9a-fA-F:]{1,39}"
-IPV6_ADDR_REGEX_3 = r"[0-9a-fA-F]{1,3}:[0-9a-fA-F]{1,3}:[0-9a-fA-F]{1,3}:[0-9a-fA-F]{1,3}:" \
-                     "[0-9a-fA-F]{1,3}:[0-9a-fA-F]{1,3}:[0-9a-fA-F]{1,3}:[0-9a-fA-F]{1,3}"
 # Should validate IPv6 address using an IP address library after matching with this regex
-IPV6_ADDR_REGEX = "(?:{}|{}|{})".format(IPV6_ADDR_REGEX_1, IPV6_ADDR_REGEX_2, IPV6_ADDR_REGEX_3)
+IPV6_ADDR_REGEX = ("(?:"
+                   "\:\:IPV4_ADDR_REGEX|"
+                   "[a-fA-F0-9\:]{2,30}IPV4_ADDR_REGEX|"
+                   "[a-fA-F0-9\:]{2,39}"
+                   ")".replace("IPV4_ADDR_REGEX", IPV4_ADDR_REGEX))
+
 
 MAC_REGEX = r"[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}"
 VLAN_REGEX = r"\d{1,4}"

--- a/test/unit/TestIOSDriver.py
+++ b/test/unit/TestIOSDriver.py
@@ -21,6 +21,45 @@ from napalm_base.test.base import TestConfigNetworkDriver, TestGettersNetworkDri
 import re
 
 
+class TestIPv4IPv6RegEx(unittest.TestCase):
+    """Test IPv4 and IPv6 regex"""
+
+    def _test_regex(self, patt, s):
+        match = patt.match(s)
+        if not match:
+            self.fail("Can't parse {}".format(s))
+        if match.group(0) != s:
+            self.fail("Parsing error: {} expected, {} found".format(
+                s, match.group(0)
+            ))
+
+    def test_ipv6_regex(self):
+        """IPv6 regex"""
+
+        lst = ['1:2:3:4:5:6:7:8', '1::', '1:2:3:4:5:6:7::', '1::8',
+               '1:2:3:4:5:6::8', '1:2:3:4:5:6::8', '1::7:8', '1:2:3:4:5::7:8',
+               '1:2:3:4:5::8', '1::6:7:8', '1:2:3:4::6:7:8', '1:2:3:4::8',
+               '1::5:6:7:8', '1:2:3::5:6:7:8', '1:2:3::8', '1::4:5:6:7:8',
+               '1:2::4:5:6:7:8', '1:2::8', '1::3:4:5:6:7:8', '1::3:4:5:6:7:8',
+               '1::8', '::2:3:4:5:6:7:8', '::2:3:4:5:6:7:8', '::8', '::',
+               '::123.12.1.0', '::255.255.255.255', '::',
+               '::ffff:255.255.255.255', '::ffff:0:255.255.255.255',
+               '2001:db8:3:4::192.0.2.33', '64:ff9b::192.0.2.33',
+               '2001:db8::1']
+        patt = re.compile(ios.IPV6_ADDR_REGEX)
+        for s in lst:
+            self._test_regex(patt, s)
+
+    def test_ipv4_regex(self):
+        """IPv4 regex"""
+
+        lst = ['0.0.0.0', '255.255.255.255', '0.1.2.3',
+               '0.0.0.255']
+        patt = re.compile(ios.IPV4_ADDR_REGEX)
+        for s in lst:
+            self._test_regex(patt, s)
+
+
 class TestConfigIOSDriver(unittest.TestCase, TestConfigNetworkDriver):
     """Configuration Tests for IOSDriver.
 


### PR DESCRIPTION
The current one seems that does not match addresses in the form `2001:DB8:A:100:1E1:B5E1:5169:96` (totally exploded, with some hextets made of 4 characters)