### PR TITLE
Get interfaces ip

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -1028,7 +1028,7 @@ class IOSDriver(NetworkDriver):
                                 'ipv6': {   u'1::1': {   'prefix_length': 64},
                                             u'2001:DB8:1::1': {   'prefix_length': 64},
                                             u'2::': {   'prefix_length': 64},
-                                            u'FE80::3': {   'prefix_length': 64}}},
+                                            u'FE80::3': {   'prefix_length': 10}}},
             u'Tunnel0': {   'ipv4': {   u'10.63.100.9': {   'prefix_length': 24}}},
             u'Tunnel1': {   'ipv4': {   u'10.63.101.9': {   'prefix_length': 24}}},
             u'Vlan100': {   'ipv4': {   u'10.40.0.1': {   'prefix_length': 24},
@@ -1054,14 +1054,12 @@ class IOSDriver(NetworkDriver):
                 continue
             if(line[0] != ' '):
                 ipv4 = {}
-                interfaces[line.split()[0]] = {'ipv4': ipv4}
+                interface_name = line.split()[0]
             m = re.match(INTERNET_ADDRESS, line)
             if m:
                 ip, prefix = m.groups()
                 ipv4.update({ip: {"prefix_length": int(prefix)}})
-
-        # Remove interfaces without ip
-        interfaces = dict(filter(lambda x: x[1]['ipv4'] != {}, interfaces.items()))
+                interfaces[interface_name] = {'ipv4': ipv4}
 
         for line in show_ipv6_interface.splitlines():
             if(len(line.strip()) == 0):
@@ -1076,7 +1074,7 @@ class IOSDriver(NetworkDriver):
             m = re.match(LINK_LOCAL_ADDRESS, line)
             if m:
                 ip = m.group(1)
-                ipv6.update({ip: {"prefix_length": 64}})
+                ipv6.update({ip: {"prefix_length": 10}})
             m = re.match(GLOBAL_ADDRESS, line)
             if m:
                 ip, prefix = m.groups()

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/expected_result.json
@@ -1,19 +1,34 @@
 {
-	"Vlan20": {
-		"ipv4": {
-			"172.29.50.3": {
-				"prefix_length": 27
-			}
-		}
-	},
-	"Vlan41": {
-		"ipv4": {
-			"172.29.52.34": {
-				"prefix_length": 27
-			},
-			"192.168.81.34": {
-				"prefix_length": 24
-			}
-		}
-	}
+        "Vlan20": {
+                "ipv4": {
+                        "172.29.50.3": {
+                                "prefix_length": 27
+                        }
+                },
+                "ipv6": {
+                        "FE80::C009:24FF:FEAC:0": {
+                                "prefix_length": 64
+                        },
+                        "2002::1": {
+                                "prefix_length": 64
+                        }
+                }
+        },
+        "Vlan41": {
+                "ipv4": {
+                        "172.29.52.34": {
+                                "prefix_length": 27
+                        },
+                        "192.168.81.34": {
+                                "prefix_length": 24
+                        }
+                }
+        },
+        "Loopback0": {
+                "ipv6": {
+                        "FE80::C009:24FF:FEAC:0": {"prefix_length": 64},
+                        "2001::1": {"prefix_length": 128},
+                        "2001::2": {"prefix_length": 128}
+                }
+        }
 }

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/expected_result.json
@@ -1,34 +1,34 @@
 {
-        "Vlan20": {
-                "ipv4": {
-                        "172.29.50.3": {
-                                "prefix_length": 27
-                        }
-                },
-                "ipv6": {
-                        "FE80::C009:24FF:FEAC:0": {
-                                "prefix_length": 64
-                        },
-                        "2002::1": {
-                                "prefix_length": 64
-                        }
-                }
-        },
-        "Vlan41": {
-                "ipv4": {
-                        "172.29.52.34": {
-                                "prefix_length": 27
-                        },
-                        "192.168.81.34": {
-                                "prefix_length": 24
-                        }
-                }
-        },
-        "Loopback0": {
-                "ipv6": {
-                        "FE80::C009:24FF:FEAC:0": {"prefix_length": 64},
-                        "2001::1": {"prefix_length": 128},
-                        "2001::2": {"prefix_length": 128}
-                }
-        }
+	"Vlan20": {
+		"ipv4": {
+			"172.29.50.3": {
+				"prefix_length": 27
+			}
+		},
+		"ipv6": {
+			"FE80::C009:24FF:FEAC:0": {
+				"prefix_length": 64
+			},
+			"2002::1": {
+				"prefix_length": 64
+			}
+		}
+	},
+	"Vlan41": {
+		"ipv4": {
+			"172.29.52.34": {
+				"prefix_length": 27
+			},
+			"192.168.81.34": {
+				"prefix_length": 24
+			}
+		}
+	},
+	"Loopback0": {
+		"ipv6": {
+			"FE80::C009:24FF:FEAC:0": {"prefix_length": 64},
+			"2001::1": {"prefix_length": 128},
+			"2001::2": {"prefix_length": 128}
+		}
+	}
 }

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/expected_result.json
@@ -7,7 +7,7 @@
 		},
 		"ipv6": {
 			"FE80::C009:24FF:FEAC:0": {
-				"prefix_length": 64
+				"prefix_length": 10
 			},
 			"2002::1": {
 				"prefix_length": 64
@@ -26,7 +26,7 @@
 	},
 	"Loopback0": {
 		"ipv6": {
-			"FE80::C009:24FF:FEAC:0": {"prefix_length": 64},
+			"FE80::C009:24FF:FEAC:0": {"prefix_length": 10},
 			"2001::1": {"prefix_length": 128},
 			"2001::2": {"prefix_length": 128}
 		}

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_ip_interface.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_ip_interface.txt
@@ -1,0 +1,87 @@
+Vlan20 is up, line protocol is up
+  Internet address is 172.29.50.3/27
+  Broadcast address is 255.255.255.255
+  Address determined by non-volatile memory
+  MTU is 1500 bytes
+  Helper addresses are 172.16.0.1
+                       192.168.1.1
+  Directed broadcast forwarding is enabled
+  Multicast reserved groups joined: 224.0.0.102 224.0.0.5 224.0.0.6
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is disabled
+  Local Proxy ARP is disabled
+  Security level is default
+  Split horizon is enabled
+  ICMP redirects are never sent
+  ICMP unreachables are never sent
+  ICMP mask replies are never sent
+  IP fast switching is enabled
+  IP Flow switching is disabled
+  IP CEF switching is enabled
+  IP CEF switching turbo vector
+  IP Null turbo vector
+  Associated unicast routing topologies:
+        Topology "base", operation state is UP
+  IP multicast fast switching is enabled
+  IP multicast distributed fast switching is disabled
+  IP route-cache flags are Fast, CEF
+  Router Discovery is disabled
+  IP output packet accounting is disabled
+  IP access violation accounting is disabled
+  TCP/IP header compression is disabled
+  RTP/IP header compression is disabled
+  Probe proxy name replies are disabled
+  Policy routing is disabled
+  Network address translation is disabled
+  BGP Policy Mapping is disabled
+  Input features: MCI Check
+  Output features: IP Post Routing Processing, HW Shortcut Installation
+  Post encapsulation features: MTU Processing, IP Protocol Output Counter, IP Sendself Check, HW Shortcut Installation
+  Sampled Netflow is disabled
+  IP Routed Flow creation is disabled in netflow table
+  IP Bridged Flow creation is disabled in netflow table
+  IPv4 WCCP Redirect outbound is disabled
+  IPv4 WCCP Redirect inbound is disabled
+  IPv4 WCCP Redirect exclude is disabled
+  IP multicast multilayer switching is disabled
+GigabitEthernet1/1 is down, line protocol is down
+GigabitEthernet1/2 is down, line protocol is down
+GigabitEthernet1/3 is administratively down, line protocol is down
+  Internet protocol processing disabled
+Vlan41 is up, line protocol is up
+  Internet address is 172.29.52.34/27
+  Broadcast address is 255.255.255.255
+  Address determined by non-volatile memory
+  MTU is 1514 bytes
+  Helper address is not set
+  Directed broadcast forwarding is disabled
+  Secondary address 192.168.81.34/24
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is enabled
+  Local Proxy ARP is disabled
+  Security level is default
+  Split horizon is enabled
+  ICMP redirects are always sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  IP fast switching is enabled
+  IP fast switching on the same interface is disabled
+  IP Flow switching is disabled
+  IP CEF switching is enabled
+  IP CEF Fast switching turbo vector
+  IP multicast fast switching is enabled
+  IP multicast distributed fast switching is disabled
+  IP route-cache flags are Fast, CEF
+  Router Discovery is disabled
+  IP output packet accounting is disabled
+  IP access violation accounting is disabled
+  TCP/IP header compression is disabled
+  RTP/IP header compression is disabled
+  Policy routing is disabled
+  Network address translation is disabled
+  BGP Policy Mapping is disabled
+  WCCP Redirect outbound is disabled
+  WCCP Redirect inbound is disabled
+  WCCP Redirect exclude is disabled

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_ip_interface_brief.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_ip_interface_brief.txt
@@ -1,6 +1,0 @@
-Interface              IP-Address      OK? Method Status                Protocol
-Vlan20                 172.29.50.3     YES NVRAM  up                    up
-Vlan40                 unassigned      YES unset  up                    up
-Vlan41                 172.29.52.34    YES NVRAM  up                    up
-GigabitEthernet0/5     unassigned      YES unset  up                    up
-Port-channel1          unassigned      YES unset  administratively down down

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_ipv6_interface.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_ipv6_interface.txt
@@ -1,0 +1,30 @@
+Vlan20 is administratively down, line protocol is down
+  IPv6 is enabled, link-local address is FE80::C009:24FF:FEAC:0 [TEN]
+  Global unicast address(es):
+    2002::1, subnet is 2002::/64 [TEN]
+  Joined group address(es):
+    FF02::1
+    FF02::1:FF00:1
+    FF02::1:FFAC:0
+  MTU is 1500 bytes
+  ICMP error messages limited to one every 100 milliseconds
+  ICMP redirects are enabled
+  ND DAD is enabled, number of DAD attempts: 1
+  ND reachable time is 30000 milliseconds
+Loopback0 is up, line protocol is up
+  IPv6 is enabled, link-local address is FE80::C009:24FF:FEAC:0
+  Global unicast address(es):
+    2001::1, subnet is 2001::1/128
+    2001::2, subnet is 2001::2/128
+  Joined group address(es):
+    FF02::1
+    FF02::2
+    FF02::1:FF00:1
+    FF02::1:FF00:2
+    FF02::1:FFAC:0
+  MTU is 1514 bytes
+  ICMP error messages limited to one every 100 milliseconds
+  ICMP redirects are enabled
+  ND DAD is not supported
+  ND reachable time is 30000 milliseconds
+

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_GigabitEthernet0_5.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_GigabitEthernet0_5.txt
@@ -1,8 +1,0 @@
-Building configuration...
-
-Current configuration : 87 bytes
-!
-interface GigabitEthernet0/5
- switchport access vlan 41
- switchport mode access
-end

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Port_channel1.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Port_channel1.txt
@@ -1,7 +1,0 @@
-Building configuration...
-
-Current configuration : 41 bytes
-!
-interface Port-channel1
- shutdown
-end

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Vlan20.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Vlan20.txt
@@ -1,7 +1,0 @@
-Building configuration...
-
-Current configuration : 64 bytes
-!
-interface Vlan20
- ip address 172.29.50.3 255.255.255.224
-end

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Vlan40.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Vlan40.txt
@@ -1,7 +1,0 @@
-Building configuration...
-
-Current configuration : 39 bytes
-!
-interface Vlan40
- no ip address
-end

--- a/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Vlan41.txt
+++ b/test/unit/mocked_data/test_get_interfaces_ip/normal/show_run_interface_Vlan41.txt
@@ -1,8 +1,0 @@
-Building configuration...
-
-Current configuration : 115 bytes
-!
-interface Vlan41
- ip address 192.168.81.34 255.255.255.0 secondary
- ip address 172.29.52.34 255.255.255.224
-end


### PR DESCRIPTION
Fix #204
As proposed in the issue by ktbyers I used ```show ip[v6] interface```.

I changed the documentation of get_interfaces_ip in the code as N/A was not accepted on link-local ipv6 prefix_length because it was not an integer. I replaced N/A by 64 which seems to be the prefix length of such addresses.