### PR TITLE
Improve napalm-ios hostname handler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 napalm_base>=0.25.0
-netmiko>=1.4.2
+netmiko>=1.4.3


### PR DESCRIPTION
Current hostname handler has issues with inconsistent failures. I believe these failures were due to not allocating enough time for operation to complete (12 seconds).

I have changed the pattern to now just search for one of the three items #, >, or the current last character of your prompt.

I tested this on both merge/replace and with hostname changes / no hostname changes.
