### PR TITLE
Add more generic check for error on config replace

### DIFF
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -407,9 +407,9 @@ class IOSDriver(NetworkDriver):
             else:
                 cmd = 'configure replace {} force'.format(cfg_file)
             output = self._commit_hostname_handler(cmd)
-            if ('Failed to apply command' in output) or \
-               ('original configuration has been successfully restored' in output) or \
-               ('Error' in output):
+            if ('original configuration has been successfully restored' in output) or \
+               ('error' in output.lower()) or \
+               ('failed' in output.lower()):
                 msg = "Candidate config could not be applied\n{}".format(output)
                 raise ReplaceConfigException(msg)
             elif '%Please turn config archive on' in output:


### PR DESCRIPTION
Add a more generic check if the config replaced has failed.

Fix for follow issue: `Writing access/switch-01/config.cfgOct--6-07-19-45.806-1 %Failed to backup current config` not discovered
