### PR TITLE
Remove download counter which doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![PyPI](https://img.shields.io/pypi/v/napalm-ios.svg)](https://pypi.python.org/pypi/napalm-ios)
-[![PyPI](https://img.shields.io/pypi/dm/napalm-ios.svg)](https://pypi.python.org/pypi/napalm-ios)
 [![Build Status](https://travis-ci.org/napalm-automation/napalm-ios.svg?branch=master)](https://travis-ci.org/napalm-automation/napalm-ios)
 [![Coverage Status](https://coveralls.io/repos/github/napalm-automation/napalm-ios/badge.svg?branch=master)](https://coveralls.io/github/napalm-automation/napalm-ios)
 


### PR DESCRIPTION
Removing the download counter which has stopped working:
[![PyPI](https://img.shields.io/pypi/dm/napalm-ios.svg)](https://pypi.python.org/pypi/napalm-ios)

It can give the wrong impression of the project. And of course, so that everything looks nice for the hacktoberfest. :)